### PR TITLE
stable release 1.5.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,6 @@
 
 environment:
 
-  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-  # /E:ON and /V:ON options are not enabled in the batch script intepreter
-  # See: http://stackoverflow.com/a/13751649/163740
-  CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
-
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: ipv/06DzgA7pzz2CIAtbPxZSsphDtF+JFyoWRnXkn3O8j7oRe3rzqj3LOoq2DZp4
@@ -67,7 +62,6 @@ install:
     - cmd: conda config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
@@ -75,6 +69,6 @@ install:
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build recipe --quiet"
+    - conda build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "datacube" %}
 {% set reponame = "datacube-core" %}
-{% set version = "1.3.2" %}
-{% set sha256 = "fb1583853cfd9bfb9b9b41a7fc9cba312f92f203a525c4dd42af3272809550eb" %}
+{% set version = "1.5.2" %}
+{% set sha256 = "e450a7a0c866bd1cbf1bc692958e10b226683403917e711716a10f667afe72ef" %}
 
 package:
   name: {{ name|lower }}
@@ -37,7 +37,13 @@ requirements:
     - rasterio
     - singledispatch
     - sqlalchemy
-    - xarray
+    - xarray >=0.9
+    - celery >=4
+    - paramiko
+    - redis
+    - sshtunnel
+    - tqdm
+
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - xarray >=0.9
     - celery >=4
     - paramiko
-    - redis  # [not win]
+    - redis-py
     - sshtunnel
     - tqdm
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - xarray >=0.9
     - celery >=4
     - paramiko
-    - redis # [not win]
+    - redis  # [not win]
     - sshtunnel
     - tqdm
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - xarray >=0.9
     - celery >=4
     - paramiko
-    - redis
+    - redis # [not win]
     - sshtunnel
     - tqdm
 


### PR DESCRIPTION
- Change version number
- Add SHA generated from Github archive copy
- Add dependencies `celery`, `paramiko`, `redis`, `sshtunnel`, `tqdm`