### PR TITLE
Conda release for 1.9.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,8 +45,8 @@ requirements:
     - lark
     - netcdf4
     - numpy >=1.26.0
-    - odc-geo >=0.5.0
-    - odc-loader <=0.6.3
+    - odc-geo >=0.5.1
+    - odc-loader <=0.6.4
     - odc-stac >=0.5.0
     - packaging
     - pandas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "datacube" %}
 {% set version = "1.9.13" %}
 {% set sha256 = "699b44784a5695209cdba4f90b98f08de11cce6e3ae3877df19555c54e2420c7" %}
-{% set python_min = "3.12" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ build:
 requirements:
   host:
     - pip
-    - python >={{ python_min }}
+    - python {{ python_min }}
     - setuptools
     - setuptools_scm >=3.4
     - toml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "datacube" %}
-{% set version = "1.9.12" %}
-{% set sha256 = "dc4bc524c4d8f5f2ef8afa31e13cb381c7bdb1b69990d6f83cc6fb5a91091678" %}
+{% set version = "1.9.13" %}
+{% set sha256 = "699b44784a5695209cdba4f90b98f08de11cce6e3ae3877df19555c54e2420c7" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -46,7 +46,7 @@ requirements:
     - netcdf4
     - numpy >=1.26.0
     - odc-geo >=0.5.0
-    - odc-loader <=0.6.0
+    - odc-loader <=0.6.3
     - odc-stac >=0.5.0
     - pandas
     - packaging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "datacube" %}
 {% set version = "1.9.13" %}
 {% set sha256 = "699b44784a5695209cdba4f90b98f08de11cce6e3ae3877df19555c54e2420c7" %}
-{% set python_min = "3.10" %}
+{% set python_min = "3.12" %}
 
 package:
   name: {{ name|lower }}
@@ -51,7 +51,7 @@ requirements:
     - packaging
     - pandas
     - psycopg2
-    - pyproj >=2.5
+    - pyproj >=3.0.0
     - python-dateutil
     - pyyaml
     - rasterio >=1.4.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "datacube" %}
 {% set version = "1.9.13" %}
 {% set sha256 = "699b44784a5695209cdba4f90b98f08de11cce6e3ae3877df19555c54e2420c7" %}
-{% set python_min = "3.10" %}
+{% set python_min = "3.11" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
   run:
     - python >={{ python_min }}
     - affine
+    - alembic
     - antimeridian <0.4.5
     - attrs >=18.1
     - boto3
@@ -39,8 +40,7 @@ requirements:
     - dask-core
     - deprecat
     - distributed
-    - pyproj >=2.5
-    - shapely >=2
+    - geoalchemy2 >=0.17.0
     - jsonschema >=4.18
     - lark
     - netcdf4
@@ -48,17 +48,18 @@ requirements:
     - odc-geo >=0.5.0
     - odc-loader <=0.6.3
     - odc-stac >=0.5.0
-    - pandas
     - packaging
+    - pandas
     - psycopg2
+    - pyproj >=2.5
     - python-dateutil
     - pyyaml
     - rasterio >=1.3.11
-    - sqlalchemy >=2.0
-    - alembic
-    - geoalchemy2 >=0.17.0
-    - xarray >2022.6.0
     - ruamel.yaml
+    - scikit-image
+    - shapely >=2
+    - sqlalchemy >=2.0
+    - xarray >2022.6.0
     - toolz
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - pyproj >=2.5
     - python-dateutil
     - pyyaml
-    - rasterio >=1.3.11
+    - rasterio >=1.4.4
     - ruamel.yaml
     - scikit-image
     - shapely >=2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,9 +45,9 @@ requirements:
     - lark
     - netcdf4
     - numpy >=1.26.0
-    - odc-geo >=0.5.1
+    - odc-geo >=0.5.0
     - odc-loader <=0.6.4
-    - odc-stac >=0.5.0
+    - odc-stac >=0.5.1
     - packaging
     - pandas
     - psycopg2


### PR DESCRIPTION
Conda autotick-bot missed the core 1.9.13 release for some reason, so I'm doing it manually.


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
